### PR TITLE
Add support for separator between prefix/label/suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ jobs:
         with:
           prefix: 'sample_prefix' # optional
           suffix: 'sample_suffix' # optional
+          separator: ' ' # optional
 ```
 
 ### Options
 
 - Optionally add a `BASE_DIRS` variable under `env` if modules are located within one or more base directory(ies). You can configure one (ex. `base_directory1`) or more directories (ex. `base_directory1|bae_directory2|...`). If `BASE_DIRS` isn't specified, the action will assume the base directories in the repo are your modules (ex. `base_directory1` is a module).
 - Add `prefix` or `suffix` under `with` if you wish to add prefix or suffix the repo name in the label respectively.
+- Add `separator` under `with` if you wish to add a separator between the prefix, label, and suffix. For example, using a single space character `'  '` will add a space between them. By default, no separator is added.
 
 ### Example: Repos in sub directories
 
@@ -77,7 +79,7 @@ jobs:
 
 ### Example: Adding a custom prefix or suffix to labels
 
-The following configuration will prefix each label with `🗂 ` - ex.`🗂 Repo A`, `🗂 Repo B`, etc:
+The following configuration will prefix each label with `🗂` and add a space after the prefix - ex.`🗂 Repo A`, `🗂 Repo B`, etc:
 
 ```yaml
 name: Monorepo PR Repo Labeler
@@ -94,7 +96,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          prefix: '🗂 ' # optional
+          prefix: '🗂' # optional
+          separator: ' ' # optional
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   suffix:
     description: Suffix to repo name to be used in label
     required: false
+  separator:
+    description: Seperator between prefix, label, and suffix (e.g., space)
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/helpers.js
+++ b/helpers.js
@@ -81,5 +81,5 @@ module.exports.getLabel = function(repo) {
   const separator = process.env.INPUT_SEPARATOR || '';
   repo = repo || '';
 
-  return `${prefix}${process.env.INPUT_SEPARATOR}${repo}${process.env.INPUT_SEPARATOR}${suffix}`.trim();
+  return `${prefix}${separator}${repo}${separator}${suffix}`.trim();
 }

--- a/helpers.js
+++ b/helpers.js
@@ -78,7 +78,8 @@ module.exports.addLabel = function(
 module.exports.getLabel = function(repo) {
   const prefix = process.env.INPUT_PREFIX || '';
   const suffix = process.env.INPUT_SUFFIX || '';
+  const separator = process.env.INPUT_SEPARATOR || '';
   repo = repo || '';
 
-  return `${prefix} ${repo} ${suffix}`.trim();
+  return `${prefix}${process.env.INPUT_SEPARATOR}${repo}${process.env.INPUT_SEPARATOR}${suffix}`.trim();
 }

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -91,25 +91,51 @@ describe('getLabel', () => {
 
     const repoName = 'sample_repo'
 
-    expect(helpers.getLabel(repoName)).toBe('sample_prefix sample_repo sample_suffix')
+    expect(helpers.getLabel(repoName)).toBe('sample_prefixsample_reposample_suffix')
   })
 
   it('Returns label only with suffix when only suffix passed as input', () => {
     process.env.INPUT_SUFFIX = 'sample_suffix'
     const repoName = 'sample_repo'
 
-    expect(helpers.getLabel(repoName)).toBe('sample_repo sample_suffix')
+    expect(helpers.getLabel(repoName)).toBe('sample_reposample_suffix')
   })
 
   it('Returns label only with prefix when only prefix passed as input', () => {
     process.env.INPUT_SUFFIX = 'sample_prefix'
     const repoName = 'sample_repo'
 
-    expect(helpers.getLabel(repoName)).toBe('sample_repo sample_prefix')
+    expect(helpers.getLabel(repoName)).toBe('sample_reposample_prefix')
   })
 
   it('Returns only repo name when no prefix & suffix', () => {
     expect(helpers.getLabel('sample_repo')).toBe('sample_repo')
+  })
+  
+    it('Returns label with prefix & suffic attached to repo name with space', () => {
+    process.env.INPUT_SEPARATOR = ' '
+    process.env.INPUT_PREFIX = 'sample_prefix'
+    process.env.INPUT_SUFFIX = 'sample_suffix'
+
+    const repoName = 'sample_repo'
+
+    expect(helpers.getLabel(repoName)).toBe('sample_prefix sample_repo sample_suffix')
+  })
+
+  it('Returns label only with suffix when only suffix passed as input with space', () => {
+    process.env.INPUT_SEPARATOR = ' '
+    process.env.INPUT_SUFFIX = 'sample_suffix'
+    const repoName = 'sample_repo'
+
+    expect(helpers.getLabel(repoName)).toBe('sample_repo sample_suffix')
+  })
+
+  it('Returns label only with prefix when only prefix passed as input with space', () => {
+    process.env.INPUT_SEPARATOR = ' '
+    process.env.INPUT_SUFFIX = 'sample_prefix'
+    const repoName = 'sample_repo'
+
+    expect(helpers.getLabel(repoName)).toBe('sample_repo sample_prefix')
   })
 
   it('returns empty string without input & without argument', () => {


### PR DESCRIPTION
This PR fixes https://github.com/TinkurLab/monorepo-pr-labeler-action/issues/40.

Instead of adding a configuration input for "Add space", I decided to use a general-purpose separator instead. With this, users can decide to add a single space, hyphen, etc., or nothing between the prefix, label, and suffix.

Example: Add a folder icon with a space (outputs "🗂 example" if the package name is "example")

```yaml
steps:
  - name: Label PRs
    uses: tinkurlab/monorepo-pr-labeler-action@master
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    with:
      prefix: '🗂'
      separator: ' '
```
Example: Add a scope (outputs "@pabio/example" if the package name is "example")

```yaml
steps:
  - name: Label PRs
    uses: tinkurlab/monorepo-pr-labeler-action@master
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    with:
      prefix: '@pabio/'
```