### PR TITLE
Correct name of actions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PRs
-        uses: tinkurlab/monorepo-pr-labeler-action@master
+        uses: TinkurLab/monorepo-pr-labeler-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_DIRS: 'folderA|folderB' # optional


### PR DESCRIPTION
> tinkurlab/monorepo-pr-labeler-action@master -> TinkurLab/monorepo-pr-labeler-action@master

it looks like the owner has been changed their username and the name of github actions is case-sensitive.