### PR TITLE
Support monorepo with a dot in its name - not starting with a dot

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -40,7 +40,7 @@ module.exports.listFiles = async function (octokit, eventOwner, eventRepo, event
 }
 
 module.exports.getMonorepo = function (baseDirectories, filePath) {
-  const regexPattern = `^${baseDirectories}([^./]*)/`
+  const regexPattern = `^${baseDirectories}(?![\.])([^/]*)/`
   var regex = new RegExp(regexPattern)
   var found = filePath.match(regex)
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -59,6 +59,15 @@ describe('getMonorepo', () => {
 
     expect(result).toBe(false)
   })
+
+  it('should return monorepo if monorepo contains a "." but does not starts with a .', async () => {
+    const fileName = 'www.site.com/main.workflow'
+    const baseDirectories = ''
+
+    const result = await helpers.getMonorepo(baseDirectories, fileName)
+
+    expect(result).toBe('www.site.com')
+  })
 })
 
 describe('addLabel', () => {


### PR DESCRIPTION
according to the docs, this action should ignore mono repos that beging with a dot:
https://github.com/TinkurLab/monorepo-pr-labeler-action/blob/f8370193b5dab0f7e2d721b7395163ead6e7d482/README.md?plain=1#L11
but it currently ignores also monorepos with a dot even if it is not the first character

this is a real use case we have and I will be glad if this can be reviewed and merged.
thanks for this great GH action!